### PR TITLE
Scheduler changes caching with trace

### DIFF
--- a/test/integration/framework/perf_utils.go
+++ b/test/integration/framework/perf_utils.go
@@ -45,6 +45,7 @@ func NewIntegrationTestNodePreparer(client clientset.Interface, countToStrategy 
 	}
 }
 
+
 func (p *IntegrationTestNodePreparer) PrepareNodes() error {
 	numNodes := 0
 	for _, v := range p.countToStrategy {
@@ -63,8 +64,8 @@ func (p *IntegrationTestNodePreparer) PrepareNodes() error {
 		Status: v1.NodeStatus{
 			Capacity: v1.ResourceList{
 				v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
-				v1.ResourceCPU:    resource.MustParse("4"),
-				v1.ResourceMemory: resource.MustParse("32Gi"),
+				v1.ResourceCPU:    resource.MustParse("16"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 			Phase: v1.NodeRunning,
 			Conditions: []v1.NodeCondition{

--- a/test/integration/scheduler_perf/scheduler_test.go
+++ b/test/integration/scheduler_perf/scheduler_test.go
@@ -17,196 +17,168 @@ limitations under the License.
 package benchmark
 
 import (
-	"fmt"
 	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/plugin/pkg/scheduler"
-	"k8s.io/kubernetes/test/integration/framework"
 	testutils "k8s.io/kubernetes/test/utils"
-	"math"
 	"testing"
 	"time"
+	"fmt"
 )
 
-const (
-	warning3K    = 100
-	threshold3K  = 30
-	threshold30K = 30
-	threshold60K = 30
-)
 
+var (
+	basePodTemplate = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "sched-perf-pod-",
+		},
+		// TODO: this needs to be configurable.
+		Spec: testutils.MakePodSpec(),
+	}
+	baseNodeTemplate = &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "sample-node-",
+		},
+		Spec: v1.NodeSpec{
+			// TODO: investigate why this is needed.
+			ExternalID: "foo",
+		},
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("32Gi"),
+			},
+			Phase: v1.NodeRunning,
+			Conditions: []v1.NodeCondition{
+				{Type: v1.NodeReady, Status: v1.ConditionTrue},
+			},
+		},
+	}
+)
 // TestSchedule100Node3KPods schedules 3k pods on 100 nodes.
 func TestSchedule100Node3KPods(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping because we want to run short tests")
 	}
-	config := getBaseConfig(100, 3000)
-	writePodAndNodeTopologyToConfig(config)
-	if err := readFromFile(); err !=nil {
+	// As of now, getting entries.
+	// TODO: Create a struct to hold file related values.
+	/*if err := getEntriesInFile(); err != nil {
+		t.Errorf("Error counting entries in file")
+	}*/
+	config := getBaseConfig(100)
+	//writePodAndNodeTopologyToConfig(config)
+	if err := readFromFile(); err != nil {
 		t.Errorf("Error reading from file")
 	}
-
-	min := schedulePods(config)
-	if min < threshold3K {
-		t.Errorf("Failing: Scheduling rate was too low for an interval, we saw rate of %v, which is the allowed minimum of %v ! ", min, threshold3K)
-	} else if min < warning3K {
-		fmt.Printf("Warning: pod scheduling throughput for 3k pods was slow for an interval... Saw a interval with very low (%v) scheduling rate!", min)
-	} else {
-		fmt.Printf("Minimal observed throughput for 3k pod test: %v\n", min)
-	}
+	schedulePods(config)
 }
-
-/*
-// TestSchedule100Node3KNodeAffinityPods schedules 3k pods using Node affinity on 100 nodes.
-func TestSchedule100Node3KNodeAffinityPods(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping because we want to run short tests")
-	}
-
-	config := getBaseConfig(100, 3000)
-	// number of Node-Pod sets with Pods NodeAffinity matching given Nodes.
-	numGroups := 10
-	nodeAffinityKey := "kubernetes.io/sched-perf-node-affinity"
-	nodeStrategies := make([]testutils.CountToStrategy, 0, numGroups)
-	for i := 0; i < numGroups; i++ {
-		nodeStrategies = append(nodeStrategies, testutils.CountToStrategy{
-			Count:    config.numNodes / numGroups,
-			Strategy: testutils.NewLabelNodePrepareStrategy(nodeAffinityKey, fmt.Sprintf("%v", i)),
-		})
-	}
-	config.nodePreparer = framework.NewIntegrationTestNodePreparer(
-		config.schedulerSupportFunctions.GetClient(),
-		nodeStrategies,
-		"scheduler-perf-",
-	)
-
-	podCreatorConfig := testutils.NewTestPodCreatorConfig()
-	for i := 0; i < numGroups; i++ {
-		pod := &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "sched-perf-node-affinity-pod-",
-			},
-			Spec: testutils.MakePodSpec(),
-		}
-		pod.Spec.Affinity = &v1.Affinity{
-			NodeAffinity: &v1.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-					NodeSelectorTerms: []v1.NodeSelectorTerm{
-						{
-							MatchExpressions: []v1.NodeSelectorRequirement{
-								{
-									Key:      nodeAffinityKey,
-									Operator: v1.NodeSelectorOpIn,
-									Values:   []string{fmt.Sprintf("%v", i)},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		podCreatorConfig.AddStrategy("sched-perf-node-affinity", config.numPods/numGroups,
-			testutils.NewCustomCreatePodStrategy(pod),
-		)
-	}
-	config.podCreator = testutils.NewTestPodCreator(config.schedulerSupportFunctions.GetClient(), podCreatorConfig)
-
-	if min := schedulePods(config); min < threshold30K {
-		t.Errorf("Too small pod scheduling throughput for 30k pods. Expected %v got %v", threshold30K, min)
-	} else {
-		fmt.Printf("Minimal observed throughput for 30k pod test: %v\n", min)
-	}
-}
-
-// TestSchedule1000Node30KPods schedules 30k pods on 1000 nodes.
-func TestSchedule1000Node30KPods(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping because we want to run short tests")
-	}
-	config := getBaseConfig(1000, 30000)
-	writePodAndNodeTopologyToConfig(config)
-	if min := schedulePods(config); min < threshold30K {
-		t.Errorf("To small pod scheduling throughput for 30k pods. Expected %v got %v", threshold30K, min)
-	} else {
-		fmt.Printf("Minimal observed throughput for 30k pod test: %v\n", min)
-	}
-}
-*/
-
-// TestSchedule2000Node60KPods schedules 60k pods on 2000 nodes.
-// This test won't fit in normal 10 minutes time window.
-// func TestSchedule2000Node60KPods(t *testing.T) {
-// 	if testing.Short() {
-// 		t.Skip("Skipping because we want to run short tests")
-// 	}
-// 	config := defaultSchedulerBenchmarkConfig(2000, 60000)
-// 	if min := schedulePods(config); min < threshold60K {
-// 		t.Errorf("To small pod scheduling throughput for 60k pods. Expected %v got %v", threshold60K, min)
-// 	} else {
-// 		fmt.Printf("Minimal observed throughput for 60k pod test: %v\n", min)
-// 	}
-// }
 
 // testConfig contains the some input parameters needed for running test-suite
 type testConfig struct {
 	// Note: We don't need numPods, numNodes anymore in this struct but keeping them for backward compatibility
-	numPods                   int
 	numNodes                  int
 	nodePreparer              testutils.TestNodePreparer
-	podCreator                *testutils.TestPodCreator
 	schedulerSupportFunctions scheduler.Configurator
 	destroyFunc               func()
-}
-
-//  baseConfig returns a minimal testConfig to be customized for different tests.
-func baseConfig() *testConfig {
-	schedulerConfigFactory, destroyFunc := mustSetupScheduler()
-	return &testConfig{
-		schedulerSupportFunctions: schedulerConfigFactory,
-		destroyFunc:               destroyFunc,
-	}
 }
 
 // getBaseConfig returns baseConfig after initializing number of nodes and pods.
 // We have to function for backward compatibility. We can combine this into baseConfig.
 // TODO: Remove this function once the backward compatibility is not needed.
-func getBaseConfig(nodes int, pods int) *testConfig {
-	config := baseConfig()
-	config.numNodes = nodes
-	config.numPods = pods
-	return config
+func getBaseConfig(nodes int) *testConfig {
+	schedulerConfigFactory, destroyFunc := mustSetupScheduler()
+	return &testConfig{
+		schedulerSupportFunctions: schedulerConfigFactory,
+		destroyFunc:               destroyFunc,
+		numNodes:                  nodes,
+	}
 }
 
+func createPod(cs clientset.Interface, pod podInfo) (*v1.Pod, error) {
+	podToBeCreated := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: pod.podName,
+			Name: pod.podName,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:  "pause",
+				Image: "kubernetes/pause",
+				Ports: []v1.ContainerPort{{ContainerPort: 80}},
+				Resources: v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse(pod.cpu),
+						v1.ResourceMemory: resource.MustParse(pod.memory),
+					},
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse(pod.cpu),
+						v1.ResourceMemory: resource.MustParse(pod.memory),
+					},
+				},
+			}},
+		},
+	}
+	return cs.Core().Pods("test-").Create(podToBeCreated)
+
+}
+
+func deletePod(cs clientset.Interface, pod podInfo) {
+	// test- is the namespace name.
+	options := &metav1.DeleteOptions{}
+	cs.Core().Pods("test-").Delete(pod.podName, options)
+}
+
+
+func generateNodes(config *testConfig) {
+	for i := 0; i < config.numNodes; i++ {
+		config.schedulerSupportFunctions.GetClient().Core().Nodes().Create(baseNodeTemplate)
+
+	}
+	return
+}
+
+func checkInScheduled(podCreated *v1.Pod, scheduledPodList []*v1.Pod) bool{
+	for _, scheduledPod:= range scheduledPodList {
+		if scheduledPod.ObjectMeta.Name == podCreated.ObjectMeta.Name {
+			return true
+		}
+	}
+	return false
+}
 
 // schedulePods schedules specific number of pods on specific number of nodes.
 // This is used to learn the scheduling throughput on various
 // sizes of cluster and changes as more and more pods are scheduled.
 // It won't stop until all pods are scheduled.
 // It returns the minimum of throughput over whole run.
-func schedulePods(config *testConfig) int32 {
+func schedulePods(config *testConfig) {
 	defer config.destroyFunc()
-	if err := config.nodePreparer.PrepareNodes(); err != nil {
-		glog.Fatalf("%v", err)
-	}
-	for _ , timeNow:= range timeList {
+	generateNodes(config)
+	cs := config.schedulerSupportFunctions.GetClient()
+	for _, timeNow := range timeList {
+		// Checking if the value is not equal to 0.
 		if timeNow != float64(0) {
 			podsToDelete := getPodsToDelete(timeNow)
 			podsToCreate := getPodsToCreate(timeNow)
-			// Both pod deletion and creation could be parallelized.
+			// Both pod deletion and creation could be parallelized(individually).
 			// First delete all the pods that are not needed.
 			for _, pod := range podsToDelete {
-				deletePod(pod)
+				deletePod(cs, pod)
 			}
 			var podList []*v1.Pod
 			// Create all the pods needed for this iteration.
 			for _, pod := range podsToCreate {
 				// If there is no error for pod creation add it to
 				// pod list.
-				pod := createPod(pod)
-				podList := append(podList, pod)
+				pod, err := createPod(cs, pod)
+				if err != nil {
+					podList = append(podList, pod)
+				}
 			}
 			for {
 				start := time.Now()
@@ -214,180 +186,21 @@ func schedulePods(config *testConfig) int32 {
 				if err != nil {
 					glog.Fatalf("%v", err)
 				}
-				if len(podList) == len(scheduled) {
+				allPodsScheduled := true
+				// Check if all the pods got scheduled.
+				// TODO: This is an expensive operation. Need to work around this.
+				for _, podCreated := range scheduled {
+					allPodsScheduled = allPodsScheduled && checkInScheduled(podCreated, scheduled)
+				}
+				// If yes, break this loop.
+				if allPodsScheduled {
+					fmt.Println(time.Since(start))
 					break
 				}
-				time.Since(start)
+
+
 			}
-			// List all the pods scheduled in infinite loop. Find if all the pods to be created are present
-			// in this list and then break.
-
 		}
 	}
-	defer config.nodePreparer.CleanupNodes()
-		config.podCreator.CreatePods()
-
-	prev := 0
-	// On startup there may be a latent period where NO scheduling occurs (qps = 0).
-	// We are interested in low scheduling rates (i.e. qps=2),
-	minQps := int32(math.MaxInt32)
-	start := time.Now()
-
-	// Bake in time for the first pod scheduling event.
-	/*for {
-		time.Sleep(50 * time.Millisecond)
-		scheduled, err := config.schedulerSupportFunctions.GetScheduledPodLister().List(labels.Everything())
-		if err != nil {
-			glog.Fatalf("%v", err)
-		}
-		// 30,000 pods -> wait till @ least 300 are scheduled to start measuring.
-		// TODO Find out why sometimes there may be scheduling blips in the beggining.
-		if len(scheduled) > config.numPods/100 {
-			break
-		}
-	}*/
-	// map minimum QPS entries in a counter, useful for debugging tests.
-	qpsStats := map[int]int{}
-
-	// Now that scheduling has started, lets start taking the pulse on how many pods are happening per second.
-	for {
-		// get pods here one by one from the data structure created from the file
-		// along with operation if the operation is create, create pod here or if it is delete
-		// delete the pod here and in the list of scheduled for verification check if the pod exists or
-		// doesn't.
-
-
-
-		// This can potentially affect performance of scheduler, since List() is done under mutex.
-		// Listing 10000 pods is an expensive operation, so running it frequently may impact scheduler.
-		// TODO: Setup watch on apiserver and wait until all pods scheduled.
-		scheduled, err := config.schedulerSupportFunctions.GetScheduledPodLister().List(labels.Everything())
-		if err != nil {
-			glog.Fatalf("%v", err)
-		}
-
-		// We will be completed when all pods are done being scheduled.
-		// return the worst-case-scenario interval that was seen during this time.
-		// Note this should never be low due to cold-start, so allow bake in sched time if necessary.
-		if len(scheduled) >= config.numPods {
-			fmt.Printf("Scheduled %v Pods in %v seconds (%v per second on average). min QPS was %v\n",
-				config.numPods, int(time.Since(start)/time.Second), config.numPods/int(time.Since(start)/time.Second), minQps)
-			return minQps
-		}
-
-		// There's no point in printing it for the last iteration, as the value is random
-		qps := len(scheduled) - prev
-		qpsStats[qps] += 1
-		if int32(qps) < minQps {
-			minQps = int32(qps)
-		}
-		fmt.Printf("%ds\trate: %d\ttotal: %d (qps frequency: %v)\n", time.Since(start)/time.Second, qps, len(scheduled), qpsStats)
-		prev = len(scheduled)
-		time.Sleep(1 * time.Second)
-	}
-}
-
-// mutateNodeSpec returns the strategy needed for creation of nodes.
-// TODO: It should take the nodespec and return the modified version of it. As of now, returning the strategies for backward compatibilty.
-func (na nodeAffinity) mutateNodeSpec(numNodes int) []testutils.CountToStrategy {
-	numGroups := na.numGroups
-	nodeAffinityKey := na.nodeAffinityKey
-	nodeStrategies := make([]testutils.CountToStrategy, 0, numGroups)
-	for i := 0; i < numGroups; i++ {
-		nodeStrategies = append(nodeStrategies, testutils.CountToStrategy{
-			Count:    numNodes / numGroups,
-			Strategy: testutils.NewLabelNodePrepareStrategy(nodeAffinityKey, fmt.Sprintf("%v", i)),
-		})
-	}
-	return nodeStrategies
-}
-
-// mutatePodSpec returns the list of pods after mutating the pod spec based on predicates and priorities.
-// TODO: It should take the podspec and return the modified version of it. As of now, returning the podlist for backward compatibilty.
-func (na nodeAffinity) mutatePodSpec(numPods int, pod *v1.Pod) []*v1.Pod {
-	numGroups := na.numGroups
-	nodeAffinityKey := na.nodeAffinityKey
-	podList := make([]*v1.Pod, 0, numGroups)
-	for i := 0; i < numGroups; i++ {
-		pod = &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "sched-perf-node-affinity-pod-",
-			},
-			Spec: testutils.MakePodSpec(),
-		}
-		pod.Spec.Affinity = &v1.Affinity{
-			NodeAffinity: &v1.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-					NodeSelectorTerms: []v1.NodeSelectorTerm{
-						{
-							MatchExpressions: []v1.NodeSelectorRequirement{
-								{
-									Key:      nodeAffinityKey,
-									Operator: v1.NodeSelectorOpIn,
-									Values:   []string{fmt.Sprintf("%v", i)},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-		podList = append(podList, pod)
-	}
-	return podList
-}
-
-// generatePodAndNodeTopology is the wrapper function for modifying both pods and node objects.
-func (inputConfig *schedulerPerfConfig) generatePodAndNodeTopology(config *testConfig) {
-	nodeAffinity := inputConfig.NodeAffinity
-	podCreatorConfig := testutils.NewTestPodCreatorConfig()
-	var nodeStrategies []testutils.CountToStrategy
-	var pod *v1.Pod
-	var podList []*v1.Pod
-	if nodeAffinity != nil {
-		// Mutate Node
-		nodeStrategies = nodeAffinity.mutateNodeSpec(config.numNodes)
-		// Mutate Pod TODO: Make this to return to podSpec.
-		podList = nodeAffinity.mutatePodSpec(config.numPods, pod)
-		numGroups := nodeAffinity.numGroups
-		for _, pod := range podList {
-			podCreatorConfig.AddStrategy("sched-perf-node-affinity", config.numPods/numGroups,
-				testutils.NewCustomCreatePodStrategy(pod),
-			)
-		}
-		config.nodePreparer = framework.NewIntegrationTestNodePreparer(
-			config.schedulerSupportFunctions.GetClient(),
-			nodeStrategies, "scheduler-perf-")
-		config.podCreator = testutils.NewTestPodCreator(config.schedulerSupportFunctions.GetClient(), podCreatorConfig)
-		// TODO: other predicates/priorities will be processed in subsequent if statements.
-	} else {
-		// Default configuration.
-		nodePreparer := framework.NewIntegrationTestNodePreparer(
-			config.schedulerSupportFunctions.GetClient(),
-			[]testutils.CountToStrategy{{Count: config.numNodes, Strategy: &testutils.TrivialNodePrepareStrategy{}}},
-			"scheduler-perf-",
-		)
-
-		podConfig := testutils.NewTestPodCreatorConfig()
-		podConfig.AddStrategy("sched-test", config.numPods, testutils.NewSimpleWithControllerCreatePodStrategy("rc1"))
-		podCreator := testutils.NewTestPodCreator(config.schedulerSupportFunctions.GetClient(), podConfig)
-		config.nodePreparer = nodePreparer
-		config.podCreator = podCreator
-	}
-	return
-}
-
-// writePodAndNodeTopologyToConfig reads a configuration and then applies it to a test configuration.
-//TODO: As of now, this function is not doing anything expect for reading input values to priority structs.
-func writePodAndNodeTopologyToConfig(config *testConfig) {
-	// High Level structure that should be filled for every predicate or priority.
-	inputConfig := &schedulerPerfConfig{
-		NodeAffinity: &nodeAffinity{
-			//number of Node-Pod sets with Pods NodeAffinity matching given Nodes.
-			numGroups:       10,
-			nodeAffinityKey: "kubernetes.io/sched-perf-node-affinity",
-		},
-	}
-	inputConfig.generatePodAndNodeTopology(config)
 	return
 }

--- a/test/integration/scheduler_perf/scheduler_test.go
+++ b/test/integration/scheduler_perf/scheduler_test.go
@@ -44,6 +44,7 @@ func TestSchedule100Node3KPods(t *testing.T) {
 	}
 	config := getBaseConfig(100, 3000)
 	writePodAndNodeTopologyToConfig(config)
+	readFromFileandFillStruct()
 	min := schedulePods(config)
 	if min < threshold3K {
 		t.Errorf("Failing: Scheduling rate was too low for an interval, we saw rate of %v, which is the allowed minimum of %v ! ", min, threshold3K)
@@ -176,6 +177,20 @@ func getBaseConfig(nodes int, pods int) *testConfig {
 	return config
 }
 
+
+// readsFromFile and creates the struct of format
+func readFromFileandFillStruct(){
+
+
+
+}
+
+// getPods gets the pod after reading from file one by one.
+func getPods() {
+
+
+}
+
 // schedulePods schedules specific number of pods on specific number of nodes.
 // This is used to learn the scheduling throughput on various
 // sizes of cluster and changes as more and more pods are scheduled.
@@ -196,7 +211,7 @@ func schedulePods(config *testConfig) int32 {
 	start := time.Now()
 
 	// Bake in time for the first pod scheduling event.
-	for {
+	/*for {
 		time.Sleep(50 * time.Millisecond)
 		scheduled, err := config.schedulerSupportFunctions.GetScheduledPodLister().List(labels.Everything())
 		if err != nil {
@@ -207,12 +222,19 @@ func schedulePods(config *testConfig) int32 {
 		if len(scheduled) > config.numPods/100 {
 			break
 		}
-	}
+	}*/
 	// map minimum QPS entries in a counter, useful for debugging tests.
 	qpsStats := map[int]int{}
 
 	// Now that scheduling has started, lets start taking the pulse on how many pods are happening per second.
 	for {
+		// get pods here one by one from the data structure created from the file
+		// along with operation if the operation is create, create pod here or if it is delete
+		// delete the pod here and in the list of scheduled for verification check if the pod exists or
+		// doesn't.
+
+
+
 		// This can potentially affect performance of scheduler, since List() is done under mutex.
 		// Listing 10000 pods is an expensive operation, so running it frequently may impact scheduler.
 		// TODO: Setup watch on apiserver and wait until all pods scheduled.

--- a/test/integration/scheduler_perf/scheduler_test.go
+++ b/test/integration/scheduler_perf/scheduler_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 	"fmt"
+	"sort"
 )
 
 
@@ -160,6 +161,7 @@ func schedulePods(config *testConfig) {
 	defer config.destroyFunc()
 	generateNodes(config)
 	cs := config.schedulerSupportFunctions.GetClient()
+	sort.Float64s(timeList)
 	for _, timeNow := range timeList {
 		// Checking if the value is not equal to 0.
 		if timeNow != float64(0) {
@@ -194,7 +196,7 @@ func schedulePods(config *testConfig) {
 				}
 				// If yes, break this loop.
 				if allPodsScheduled {
-					fmt.Printf("At: %f, PodsCreated: %d, TimeTaken: %v\n", timeNow, len(podsToCreate), time.Since(start))
+					fmt.Printf("At: %f, PodsCreated: %d, PodsDelete: %d, TimeTaken: %v\n", timeNow, len(podsToCreate), len(podsToDelete), time.Since(start))
 					break
 				}
 

--- a/test/integration/scheduler_perf/scheduler_test.go
+++ b/test/integration/scheduler_perf/scheduler_test.go
@@ -194,7 +194,7 @@ func schedulePods(config *testConfig) {
 				}
 				// If yes, break this loop.
 				if allPodsScheduled {
-					fmt.Println(time.Since(start))
+					fmt.Printf("At: %f, PodsCreated: %d, TimeTaken: %v\n", timeNow, len(podsToCreate), time.Since(start))
 					break
 				}
 

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -116,6 +116,25 @@ type podInfo struct {
 }
 
 
+var noOfEntries int64
+
+func getEntriesInFile() error {
+	// Replace it with os.getCwd() and append string.
+	file, err := os.Open("/home/ravig/Projects/Personal/Golang_Practice/readFileUpdated.txt")
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+
+	noOfEntries = 1
+	for scanner.Scan() {
+		noOfEntries++
+	}
+	return nil
+}
+
+
 // To hold all the pods read from file.
 // TODO: As of now, reads a maximum of 3000, need to change it to read from whole values.
 var podInfoList = make([]podInfo, 3000)
@@ -128,7 +147,7 @@ var timeList = make([]float64, 3000)
 // once from file and fill all the datastructures we need.
 func readFromFile() error {
 	// Replace it with os.getCwd() and append string.
-	file, err := os.Open("readFileUpdated.txt")
+	file, err := os.Open("/home/ravig/Projects/Personal/Golang_Practice/readFileUpdated.txt")
 	if err != nil {
 		return err
 	}

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -966,8 +966,11 @@ func (c *TestPodCreator) CreatePods() error {
 	return nil
 }
 
-// readRandomlyGeneratedDataFromFile reads the whole into memory at a time and returns the memory and cpu to be used for container.
-func readRandomlyGeneratedDataFromFile() (map[int][]string, error) {
+// readFromTrace reads the whole into memory at a time and returns the memory and cpu to be used for container.
+// The trace should of format given in sample.txt, which is in github.
+// A sample entry should be:
+// START_TIME=600000000,END_TIME=900000000,MEM=137Mi,CPU=51m
+func readFromTraceFile() (map[int][]string, error) {
 	// Replace it with os.getCwd() and append string.
 	file, err := os.Open("/home/ravig/go/src/k8s.io/kubernetes/test/utils/sample.txt")
 	if err != nil {
@@ -981,8 +984,8 @@ func readRandomlyGeneratedDataFromFile() (map[int][]string, error) {
 	memDefault := "0m"
 	for scanner.Scan() {
 		tokens := strings.Split(scanner.Text(), ",")
-		cpu := strings.Split(tokens[0], " ")[1]
-		memory := strings.Split(tokens[1], " ")[1]
+		cpu := strings.Split(tokens[0], " ")[2]
+		memory := strings.Split(tokens[1], " ")[3]
 		if cpu == "" {
 			cpu = cpuDefault
 		}
@@ -1034,7 +1037,7 @@ func makeCreatePod(client clientset.Interface, namespace string, podTemplate *v1
 func createPod(client clientset.Interface, namespace string, podCount int, podTemplate *v1.Pod) error {
 	var createError error
 	lock := sync.Mutex{}
-	resourceDict, err := readRandomlyGeneratedDataFromFile()
+	resourceDict, err := readFromTraceFile()
 	if err != nil {
 		return fmt.Errorf("Problem while reading from file: %v", err)
 	}

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -968,7 +968,6 @@ func (c *TestPodCreator) CreatePods() error {
 
 // readRandomlyGeneratedDataFromFile reads the whole into memory at a time and returns the memory and cpu to be used for container.
 func readRandomlyGeneratedDataFromFile() (map[int][]string, error) {
-	fmt.Println("File not opening")
 	// Replace it with os.getCwd() and append string.
 	file, err := os.Open("/home/ravig/go/src/k8s.io/kubernetes/test/utils/sample.txt")
 	if err != nil {


### PR DESCRIPTION
@ataturk - I have done changes as discussed with you last time. Please create one more branch instead of master. Let me know, if there is something missing or not working.

Following is the output that we get:

./test-performance.sh 
/home/ravig/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/integration/scheduler_perf /home/ravig/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/integration/scheduler_perf
etcd --advertise-client-urls http://127.0.0.1:2379 --data-dir /tmp/tmp.2c8CW4QMh9 --listen-client-urls http://127.0.0.1:2379 --debug > "/dev/null" 2>/dev/null
Waiting for etcd to come up.
+++ [0806 00:11:26] On try 2, etcd: : http://127.0.0.1:2379
{"action":"set","node":{"key":"/_test","value":"","modifiedIndex":4,"createdIndex":4}}
+++ [0806 00:11:26] performance test (density) start
At: 1.000000, PodsCreated: 6, TimeTaken: 3.218µs
At: 1.500000, PodsCreated: 0, TimeTaken: 2.577µs
At: 1.486670, PodsCreated: 0, TimeTaken: 2.689µs
At: 1.166670, PodsCreated: 2, TimeTaken: 1.976µs
At: 1.583330, PodsCreated: 0, TimeTaken: 2.225µs
PASS
ok  	k8s.io/kubernetes/test/integration/scheduler_perf	2.948s
+++ [0806 00:11:41] ...density tests finished
/home/ravig/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/integration/scheduler_perf
+++ [0806 00:11:41] performance test cleanup complete
Each time(in microseconds) points to an entry in timeList array which is made from trace file.

